### PR TITLE
Fix some issues with url and slashes

### DIFF
--- a/source/Simple301/App_Plugins/SimpleRedirects/app.html
+++ b/source/Simple301/App_Plugins/SimpleRedirects/app.html
@@ -56,8 +56,8 @@
                                         <input class="form-control" type="checkbox" ng-model="item.IsRegex" ng-disabled="!item.$edit" no-dirty-check />
                                     </td>
                                     <td data-title="'Old Url'" sortable="'OldUrl'">
-                                        <span ng-if="!item.$edit && item.IsRegex">{{item.OldUrl}}</span>
-                                        <a ng-if="!item.$edit && !item.IsRegex" href="{{item.OldUrl}}" target="_blank">{{item.OldUrl}}</a>
+                                        <span ng-if="!item.$edit && item.IsRegex">{{item.OldUrl != '' ? item.OldUrl : '/'}}</span>
+                                        <a ng-if="!item.$edit && !item.IsRegex" href="{{item.OldUrl != '' ? item.OldUrl : '/'}}" target="_blank">{{item.OldUrl != '' ? item.OldUrl : '/'}}</a>
                                         <div ng-if="item.$edit"><input class="form-control" type="text" ng-model="item.OldUrl" placeholder="Old Url" no-dirty-check /></div>
                                     </td>
                                     <td data-title="'New Url'" sortable="'NewUrl'">

--- a/source/Simple301/Core/Components/DatabaseUpgradeComponent.cs
+++ b/source/Simple301/Core/Components/DatabaseUpgradeComponent.cs
@@ -29,7 +29,8 @@ namespace SimpleRedirects.Core.Components
             plan.From(string.Empty)
                 .To<InitialMigration>("state-1")
                 .To<RegexMigration>("state-2")
-                .To<RedirectCodeMigration>("state-3");
+                .To<RedirectCodeMigration>("state-3")
+                .To<TrimOldUrlMigration>("state-4");
 
             var upgrader = new Upgrader(plan);
             upgrader.Execute(_scopeProvider, _migrationBuilder, _keyValueService, _logger);

--- a/source/Simple301/Core/Migrations/TrimOldUrlMigration.cs
+++ b/source/Simple301/Core/Migrations/TrimOldUrlMigration.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using SimpleRedirects.Core.Models;
+using Umbraco.Core.Migrations;
+using Umbraco.Core.Persistence.Repositories;
+
+namespace SimpleRedirects.Core.Migrations
+{
+    public class TrimOldUrlMigration : MigrationBase
+    {
+        public TrimOldUrlMigration(IMigrationContext context) : base(context)
+        {
+        }
+
+        public override void Migrate()
+        {
+            if (!TableExists("Redirects")) return;
+
+            var redirects = Database.Query<Redirect>("SELECT * FROM Redirects");
+            foreach (var redirect in redirects.Where(it => !it.IsRegex))
+            {
+                redirect.OldUrl = CleanUrl(redirect.OldUrl);
+                Database.Update(redirect);
+            }
+        }
+
+        private string CleanUrl(string url)
+        {
+            var urlParts = url.ToLowerInvariant().Split('?');
+            var baseUrl = urlParts[0].TrimEnd('/');
+            return urlParts.Length == 1 ? baseUrl : $"{baseUrl}?{string.Join("?", urlParts.Skip(1))}";
+        }
+    }
+}

--- a/source/Simple301/Core/Migrations/TrimOldUrlMigration.cs
+++ b/source/Simple301/Core/Migrations/TrimOldUrlMigration.cs
@@ -1,8 +1,7 @@
-using System;
 using System.Linq;
 using SimpleRedirects.Core.Models;
 using Umbraco.Core.Migrations;
-using Umbraco.Core.Persistence.Repositories;
+using Umbraco.Core.Persistence;
 
 namespace SimpleRedirects.Core.Migrations
 {
@@ -16,8 +15,11 @@ namespace SimpleRedirects.Core.Migrations
         {
             if (!TableExists("Redirects")) return;
 
-            var redirects = Database.Query<Redirect>("SELECT * FROM Redirects");
-            foreach (var redirect in redirects.Where(it => !it.IsRegex))
+            var redirects = Database.Fetch<Redirect>(Database.SqlContext.Sql()
+                .SelectAll()
+                .From<Redirect>()
+                .Where<Redirect>(it => !it.IsRegex));
+            foreach (var redirect in redirects)
             {
                 redirect.OldUrl = CleanUrl(redirect.OldUrl);
                 Database.Update(redirect);

--- a/source/Simple301/Core/RedirectContentFinder.cs
+++ b/source/Simple301/Core/RedirectContentFinder.cs
@@ -21,7 +21,6 @@ namespace SimpleRedirects.Core
         public bool TryFindContent(PublishedRequest request)
         {
             //Check the table
-            Current.Logger.Info(typeof(RedirectContentFinder), "Request: " + request.Uri.ToString());
             var matchedRedirect = _repository.FindRedirect(request.Uri);
             if (matchedRedirect == null) return false;
 

--- a/source/Simple301/Core/RedirectContentFinder.cs
+++ b/source/Simple301/Core/RedirectContentFinder.cs
@@ -1,6 +1,7 @@
 using Umbraco.Web.Routing;
 using System.Linq;
 using System.Net;
+using Umbraco.Core.Composing;
 
 namespace SimpleRedirects.Core
 {
@@ -20,6 +21,7 @@ namespace SimpleRedirects.Core
         public bool TryFindContent(PublishedRequest request)
         {
             //Check the table
+            Current.Logger.Info(typeof(RedirectContentFinder), "Request: " + request.Uri.ToString());
             var matchedRedirect = _repository.FindRedirect(request.Uri);
             if (matchedRedirect == null) return false;
 

--- a/source/Simple301/Core/RedirectRepository.cs
+++ b/source/Simple301/Core/RedirectRepository.cs
@@ -268,7 +268,6 @@ namespace SimpleRedirects.Core
         {
             var absoluteUri = CleanUrl(oldUrl.AbsoluteUri);
             var pathAndQuery = CleanUrl(oldUrl.PathAndQuery);
-            Current.Logger.Info(typeof(RedirectRepository), "AbsoluteUri: " + absoluteUri + " pathAndQuery: " + pathAndQuery);
             return fromCache
                 ? _cacheManager.GetAndSet(CACHE_CATEGORY, "UriRedirects" + oldUrl.AbsoluteUri,
                     () => FetchRedirectFromDbByQuery(x =>

--- a/source/Simple301/SimpleRedirects.csproj
+++ b/source/Simple301/SimpleRedirects.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Core\Migrations\InitialMigration.cs" />
     <Compile Include="Core\Migrations\RegexMigration.cs" />
     <Compile Include="Core\Migrations\RedirectCodeMigration.cs" />
+    <Compile Include="Core\Migrations\TrimOldUrlMigration.cs" />
     <Compile Include="Core\Models\AddRedirectRequest.cs" />
     <Compile Include="Core\Models\AddRedirectResponse.cs" />
     <Compile Include="Core\Models\DeleteRedirectResponse.cs" />


### PR DESCRIPTION
Some urls are not being redirected correctly and this happens because of slashes.

In Umbraco, the following logic happens:
If the url is just the domain, it'll show with a slash behind it.
If the url is not the domain, it'll show without a slash behind it.

This shouldn't matter for redirects, but it does. By trimming every url, this shouldn't be a problem anymore.